### PR TITLE
Add CV timeline page

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: CV
+permalink: /cv/
+nav: true
+nav_order: 3
+---
+
+<ul class="timeline">
+  <li>
+    <span class="badge badge-toc">2013–2016</span>
+    Undergraduate student at <a href="https://www.wm.edu/">College of William and Mary</a>
+  </li>
+  <li>
+    <span class="badge badge-toc">2017–2020</span>
+    Staff Engineer at <a href="https://www.fandr.com/">Froehling &amp; Robertson</a>
+  </li>
+  <li>
+    <span class="badge badge-toc">2020–2022</span>
+    Graduate student at <a href="https://www.harvard.edu/">Harvard University</a>
+  </li>
+  <li>
+    <span class="badge badge-toc">2023–2025</span>
+    Data Scientist at <a href="https://epoch.ai/">Epoch AI</a>
+  </li>
+</ul>
+
+---


### PR DESCRIPTION
## Summary
- add CV page with timeline of education and work history

## Testing
- `pre-commit run --files _pages/cv.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b9d7bd78608321bfa741bd232f8e23