### PR TITLE
Fix broken links and add placeholder pages

### DIFF
--- a/_news/placeholder.md
+++ b/_news/placeholder.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Placeholder News
+date: 2024-01-01
+---
+
+News content will be written here later.

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Projects
+permalink: /projects/
+---
+
+This page will showcase my projects. Content coming soon.

--- a/_projects/placeholder.md
+++ b/_projects/placeholder.md
@@ -1,0 +1,6 @@
+---
+layout: project
+title: Placeholder Project
+---
+
+Details about this project will be added soon.

--- a/al-folio-readme.md
+++ b/al-folio-readme.md
@@ -49,12 +49,10 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://jay-sarkar.github.io/" target="_blank">★</a>
 <a href="https://aborowska.github.io/" target="_blank">★</a>
 <a href="https://aditisgh.github.io/" target="_blank">★</a>
-<a href="https://alexhaydock.co.uk/" target="_blank">★</a>
 <a href="https://alixkeener.net/" target="_blank">★</a>
 <a href="https://andreea7b.github.io/" target="_blank">★</a>
 <a href="https://rishabhjoshi.github.io/" target="_blank">★</a>
 <a href="https://sheelabhadra.github.io/" target="_blank">★</a>
-<a href="https://giograno.me/" target="_blank">★</a>
 <a href="https://immsrini.github.io/" target="_blank">★</a>
 <a href="https://apooladian.github.io/" target="_blank">★</a>
 <a href="https://chinmoy-dutta.github.io/" target="_blank">★</a>
@@ -65,7 +63,6 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://www.compphys.de/" target="_blank">★</a>
 <a href="https://julianstreyczek.github.io" target="_blank">★</a>
 <a href="https://sdaza.com" target="_blank">★</a>
-<a href="https://niweera.gq" target="_blank">★</a>
 <a href="https://www.alihkw.com" target="_blank">★</a>
 <a href="https://amirpourmand.ir" target="_blank">★</a>
 <a href="https://scottleechua.github.io" target="_blank">★</a>
@@ -103,7 +100,6 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://bajinsheng.github.io/" target="_blank">★</a>
 <a href="https://www.silviofanzon.com/" target="_blank">★</a>
 <a href="https://kaikaiyao.github.io/" target="_blank">★</a>
-<a href="https://alchemz.github.io/" target="_blank">★</a>
 <a href="https://samadamday.com/" target="_blank">★</a>
 <a href="https://fanpu.io/" target="_blank">★</a>
 <a href="https://abigalekim.github.io/" target="_blank">★</a>
@@ -124,8 +120,6 @@ Feel free to add your own page(s) by sending a PR.
 <a href="https://www.zhivotenko.com/" target="_blank">★</a>
 <a href="https://giordanodaloisio.github.io/" target="_blank">★</a>
 <a href="https://aadityaura.github.io/" target="_blank">★</a>
-<a href="https://abhinav-mehta.github.io/" target="_blank">★</a>
-<a href="https://shubhashisroydipta.com/" target="_blank">★</a>
 <a href="https://astanziola.github.io" target="_blank">★</a>
 <a href="https://tinkerer.in" target="_blank">★</a>
 <a href="https://sam-bieberich.github.io/" target="_blank">★</a>
@@ -148,7 +142,6 @@ Feel free to add your own page(s) by sending a PR.
 <tr>
 <td>Labs</td>
 <td>
-<a href="https://www.haylab.caltech.edu/" target="_blank">★</a>
 <a href="https://sjkimlab.github.io/" target="_blank">★</a>
 <a href="https://systemconsultantgroup.github.io/scg-folio/" target="_blank">★</a>
 <a href="https://decisionlab.ucsf.edu/" target="_blank">★</a>
@@ -429,7 +422,6 @@ Our most active contributors are welcome to join the maintainers team. If you ar
   <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="http://maruan.alshedivat.com"><img src="https://avatars.githubusercontent.com/u/2126561?v=4" width="100px;" alt=""/><br /><sub><b>Maruan</b></sub></a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://rohandebsarkar.github.io"><img src="https://avatars.githubusercontent.com/u/50144004?v=4" width="100px;" alt=""/><br /><sub><b>Rohan Deb Sarkar</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://amirpourmand.ir"><img src="https://avatars.githubusercontent.com/u/32064808?v=4" width="100px;" alt=""/><br /><sub><b>Amir Pourmand</b></sub></a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://george-gca.github.io/"><img src="https://avatars.githubusercontent.com/u/31376482?v=4" width="100px;" alt=""/><br /><sub><b>George</b></sub></a></td>
     </tr>


### PR DESCRIPTION
## Summary
- remove dead external links from user community, labs, and maintainer sections
- add placeholder Projects, News, and Project entry pages to resolve missing internal links

## Testing
- `pre-commit run --files al-folio-readme.md _pages/projects.md _projects/placeholder.md _news/placeholder.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68b9df2602ec8321901098bc89df739b